### PR TITLE
support for rut with preceding zeroes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -296,7 +296,7 @@ impl Rut {
         if regex.is_match(input) {
             let captures = regex.captures(input).unwrap();
             let number: u32 = captures["number"].replace(".", "").parse().unwrap();
-            let dv = captures["dv"].to_uppercase().chars().nth(0).unwrap();
+            let dv = captures["dv"].to_uppercase().chars().next().unwrap();
             Ok(Rut { number, dv })
         } else {
             Err(Error::InvalidFormat)
@@ -310,7 +310,7 @@ impl Rut {
         match dv {
             10 => 'K',
             11 => '0',
-            _ => format!("{}", dv).chars().nth(0).unwrap(),
+            _ => format!("{}", dv).chars().next().unwrap(),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -321,7 +321,7 @@ mod rut_test {
 
     #[test]
     fn from() {
-        let valid_rut = ["17951585-7", "5.665.328-7", "241367738"];
+        let valid_rut = ["17951585-7", "5.665.328-7", "241367738", "00017951585-7"];
         for rut in valid_rut.iter() {
             assert!(Rut::from(rut).is_ok())
         }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,5 @@
 pub(crate) const PATTERN: &str =
-    r"^(?P<number>\d{1,2}(?:\.)?\d{3}(?:\.)?\d{3})(?:-)?(?P<dv>(?i)K|\d)$";
+    r"^0*(?P<number>\d{1,2}(?:\.)?\d{3}(?:\.)?\d{3})(?:-)?(?P<dv>(?i)K|\d)$";
 
 pub(crate) fn mod_eleven(number: u8) -> u8 {
     11 - (number % 11)


### PR DESCRIPTION
This PR resolves issue #8 as alternative for PR #11.

I only changed the REGEX to add support for preceding zeroes.

I had to replace the `nth(0)` calls with `next()` to pass the husky precommit checks.